### PR TITLE
Fetch all commits before running tests to make linter pass

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-node@v1
       with:
         node-version: '14.x'


### PR DESCRIPTION
Fix for the linter to pass the tests. 


Related issue: https://github.com/sindresorhus/awesome-lint/issues/105#issuecomment-637475566

You can see this eliminates the repo age linter error here: https://github.com/etelsv/awesome-prisma/runs/730660991

