### PR TITLE
Add Archibase.dev to schema visualization tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ This is a collection of **awesome resources** about [Prisma](https://www.prisma.
 - [DBML Generator](https://github.com/notiz-dev/prisma-dbml-generator)
 - [Prisma ERD Generator](https://github.com/keonik/prisma-erd-generator)
 - [Prismaliser - Visualise your Prisma schema models and relations](https://prismaliser.ovy.cloud/)
+- [Archibase - Collaborative schema editor based on Prisma SDL](https://archibase.dev/)
 
 ## :thinking: How Tos
 


### PR DESCRIPTION
As @2color suggested me, I would like to add [Archibase](https://www.archibase.dev) to the schema visualization tools. 

Archibase lets you build, visualize and document your Prisma schema and implements a realtime collaboration for teams to ideate faster. 
Archibase uses the Prisma SDL we know and love as the primary way to define relations and entities of the database. 

It has a free plan and an open demo [here](https://www.archibase.dev/demo) if you want to check it out. 

Cheers