### PR TITLE
Add prisma-ast to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ This is a collection of **awesome resources** about [Prisma](https://www.prisma.
 - [Prisma Yup Generator - Prisma 2+ generator to emit Yup schemas from your Prisma schema](https://github.com/omar-dulaimi/prisma-yup-generator)
 - [Schemix - Generate Prisma Schemas with TypeScript](https://github.com/ridafkih/schemix)
 - [Prismock - Run tests in isolation with an in-memory implementation of Prisma](https://github.com/morintd/prismock)
+- [prisma-ast - A Builder object to programmatically query and edit your schema.prisma files](https://github.com/MrLeebo/prisma-ast)
 
 ### :man_technologist: Prisma Clients
 


### PR DESCRIPTION
I am the author of prisma-ast.

It uses an abstract syntax tree to parse your schema.prisma files and exposes a fluent builder object to allow you to query and edit your schemas. prisma/sdk's DMMF config format doesn't expose details about the schema that aren't relevant to the prisma client. This means that prisma-ast parses attributes, comments, and line breaks that the DMMF would ignore.