### PR TITLE
Add prisma-query-formatter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ This is a collection of **awesome resources** about [Prisma](https://www.prisma.
 - [Schemix - Generate Prisma Schemas with TypeScript](https://github.com/ridafkih/schemix)
 - [Prismock - Run tests in isolation with an in-memory implementation of Prisma](https://github.com/morintd/prismock)
 - [prisma-ast - A Builder object to programmatically query and edit your schema.prisma files](https://github.com/MrLeebo/prisma-ast)
+- [prisma-query-formatter - Substitute params and format queries for logging](https://github.com/s1owjke/prisma-query-formatter)
 
 ### :man_technologist: Prisma Clients
 


### PR DESCRIPTION
This package solves the old problem of not being able to output queries with parameters for debugging purposes.

It's a small zero-dependency utility that replaces placeholders with their corresponding param values and converts raw queries into a consistent single-line format used by Prisma itself.